### PR TITLE
Add Ubuntu 24 support for binaries via launchpad

### DIFF
--- a/files/rabbitmq.launchpad.list
+++ b/files/rabbitmq.launchpad.list
@@ -1,2 +1,2 @@
-deb https://packages.erlang-solutions.com/ubuntu focal contrib
+deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main
 deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ focal main

--- a/files/rabbitmq.launchpad.list
+++ b/files/rabbitmq.launchpad.list
@@ -1,2 +1,2 @@
-deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu noble main
+deb https://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu noble main
 deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ noble main

--- a/files/rabbitmq.launchpad.list
+++ b/files/rabbitmq.launchpad.list
@@ -1,2 +1,2 @@
-deb https://packages.erlang-solutions.com/ubuntu focal contrib
-deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ focal main
+deb https://packages.erlang-solutions.com/ubuntu noble contrib
+deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ noble main

--- a/files/rabbitmq.launchpad.list
+++ b/files/rabbitmq.launchpad.list
@@ -1,2 +1,2 @@
-deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main
+deb https://packages.erlang-solutions.com/ubuntu focal contrib
 deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ focal main

--- a/files/rabbitmq.launchpad.list
+++ b/files/rabbitmq.launchpad.list
@@ -1,2 +1,2 @@
-deb https://packages.erlang-solutions.com/ubuntu noble contrib
+deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu noble main
 deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ noble main

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -5,6 +5,12 @@
     state: present
   when: not rabbitmq_os_package
 
+- name: Add erlang repository's key
+  apt_key:
+    url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
+    state: present
+  when: not rabbitmq_os_package
+
 - name: Add rabbitmq repository's key
   apt_key:
     keyserver: "keyserver.ubuntu.com"

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -10,7 +10,7 @@
     url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
     state: present
   when: not rabbitmq_os_package
-  
+
 - name: Add rabbitmq repository's key
   apt_key:
     keyserver: "keyserver.ubuntu.com"

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -5,6 +5,12 @@
     state: present
   when: not rabbitmq_os_package
 
+- name: Add erlang repository's key
+  apt_key:
+    url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
+    state: present
+  when: not rabbitmq_os_package
+  
 - name: Add rabbitmq repository's key
   apt_key:
     keyserver: "keyserver.ubuntu.com"

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -5,12 +5,6 @@
     state: present
   when: not rabbitmq_os_package
 
-- name: Add erlang repository's key
-  apt_key:
-    url: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"
-    state: present
-  when: not rabbitmq_os_package
-
 - name: Add rabbitmq repository's key
   apt_key:
     keyserver: "keyserver.ubuntu.com"


### PR DESCRIPTION
## Description
Add launchpad as the source repository for Erlang since it's the recommended source of binaries by Rabbitmq and the erlang-solutions version does not provide the required version. 

## Motivation and Context
The erlang-solution source does not provide the right version of Erlang for the Ubuntu 24 distribution. Therefore, when trying to build an AMI with Ubuntu 24 it fails saying the binaries were not found. 

Wil be tagged with rabbitmq-test and standard tags so we can differentiate which one is being used. Would you like different naming? 

## How Has This Been Tested?
Tested on a Rabbit test cluster with rabbit 3.13.7 and Ubuntu 24. 

